### PR TITLE
Fix MakeFile for Windows 10

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,7 +27,7 @@ in include/sahmt.h], but the alignment algorithm will be slow.
 Also, chance matches leading to insignificant alignments will be
 more prevalent for long cDNAs.  For such applications, use of
 the options "-x", "-y", and "-z" with higher than default values
-is recommended.  
+is recommended.
 
 __DATABASE SUPPORT:__
 Please see 0README in the DBsupport directory for
@@ -60,6 +60,12 @@ cd ../demo		#(see 0README_EXAMPLES)
 #
 $make INSTALLDIR=~/bin install
 $)
+
+# Note: If your are planning on Windows 10, I would suggest reading through this tutorial first:
+#       https://docs.microsoft.com/en-us/cpp/build/walkthrough-compiling-a-native-cpp-program-on-the-command-line?view=vs-2019
+#
+#       Once you have a developer command prompt, the installation method above can be used.
+#       [system-type] -> win
 ```
 
 __BINARIES:__

--- a/include/daPbm7.h
+++ b/include/daPbm7.h
@@ -90348,7 +90348,7 @@ double is_donor(char seq[], int numbp, int pos, int wl, int species, struct ssit
 {
   int i, j, p, c, S1, S2, d, gcspecies = 0, gcdonor = 0;
   struct bcvct bcvl, bcvr;
-  double delU = 0.0, delS = 0.0, Tv[3] = {}, Fv[4] = {}, pval = -0.5, cval = -99.0;
+  double delU = 0.0, delS = 0.0, Tv[3], Fv[4], pval = -0.5, cval = -99.0;
   int mutate = 0, seqo1=0, seqo2=0;
 
   if (seq[pos] != 3  ||  seq[pos + 1] != 0) {
@@ -90490,7 +90490,7 @@ else {
 double is_acptr(char seq[], int numbp, int pos, int wl, int species, struct ssite_stats *psite, int allownn)
 {
   int i, j, p, c, S1, S2, d;
-  double delU = 0.0, delS = 0.0, Tv[3] = {}, Fv[4] = {}, pval = -0.5, cval = -99.0;
+  double delU = 0.0, delS = 0.0, Tv[3], Fv[4], pval = -0.5, cval = -99.0;
   int qlty_branchpoint(char seq[], int numbp, int pos, int wa, int wb);
   struct bcvct bcvl, bcvr;
   int mutate = 0, seqo1=0, seqo2=0;
@@ -90604,7 +90604,7 @@ double is_acptr(char seq[], int numbp, int pos, int wl, int species, struct ssit
 double donorP(char seq[], int numbp, int pos, int species)
 {
   int i, j, p, c, S1, S2, d, gcspecies = 0, gcdonor = 0;
-  double pval = 0.5, Tv[3] = {}, Fv[4] = {};
+  double pval = 0.5, Tv[3], Fv[4];
 
   if (pos < 0  ||  pos >= numbp-1  ||  seq[pos] != 3) return (-1.0);
   if (species != 8  &&  species != 10  &&  species != 11 &&  species != 12  &&  seq[pos + 1] != 0) return (-1.0);
@@ -90718,7 +90718,7 @@ else {
 double acptrP(char seq[], int numbp, int pos, int species)
 {
   int i, j, p, c, S1, S2, d;
-  double pval = 0.5, Tv[3] = {}, Fv[4] = {};
+  double pval = 0.5, Tv[3], Fv[4];
 
   if (pos == 0  ||  (seq[pos - 1] != 2 || seq[pos] != 3)) {
     return (-1.0);

--- a/include/sahmt.h
+++ b/include/sahmt.h
@@ -1,1 +1,1 @@
-../include/sahmt.hSML
+#include "../include/sahmt.hSML"

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,8 +1,13 @@
 #Makefile for GeneSeqer/SplicePredictor
 #Last update: February 11, 2019.
 
-BINDIR     = ../bin
-INSTALLDIR = /usr/local/bin
+ifeq ($(OS),Windows_NT)
+	BINDIR     = ..\bin
+	INSTALLDIR = "%programfiles(x86)%\GeneSeqer\bin"
+else
+	BINDIR     = ../bin
+	INSTALLDIR = /usr/local/bin
+endif
 
 what:
 	clear;
@@ -43,7 +48,10 @@ sun-os:
 	@make -f makefile.sun
 
 win:
-	mkdir -p $(BINDIR)
+# Check if file exists, create it if it doesn't
+ifeq ("$(wildcard $(BINDIR))", "")
+	mkdir $(BINDIR)
+endif
 	@make -f makefile.win
 
 OPENMPI:
@@ -54,10 +62,22 @@ OPENMPI:
 
 
 install:
+ifeq ($(OS),Windows_NT)
+	xcopy /f $(BINDIR)\* $(INSTALLDIR)
+else
 	cp $(BINDIR)/* $(INSTALLDIR)/
+endif
 
 clean:
+ifeq ($(OS),Windows_NT)
+	del /f *.obj
+else
 	\rm *.o
+endif
 
 allclean:
+ifeq ($(OS),Windows_NT)
+	del /f *.o ..\bin\GeneSeqer* ..\bin\MakeArray ..\bin\SplicePredictor*
+else
 	\rm *.o ../bin/GeneSeqer* ../bin/MakeArray ../bin/SplicePredictor*
+endif

--- a/src/makefile.win
+++ b/src/makefile.win
@@ -7,51 +7,54 @@ CFLAGS   = -D$(PLATFORM) -I$(INCLDIR)
 all:	MakeArray GeneSeqer SplicePredictor SplicePredictorLL
 
 
-MOBJS    = MakeArray.obj \
-	   DbSuffix.obj \
-	   SufArray.obj \
-	   EstData.obj \
-	   LcpTree.obj \
-	   RawTextFile.obj \
-	   TopsPage.obj \
-	   TopsPost.obj \
-	   TopsSeq.obj \
-	   TopsWire.obj
+MOBJS = MakeArray.obj \
+	DbSuffix.obj \
+	SufArray.obj \
+	EstData.obj \
+	LcpTree.obj \
+	RawTextFile.obj \
+	TopsPage.obj \
+	TopsPost.obj \
+	TopsSeq.obj \
+	TopsWire.obj
 
 MakeArray:	$(MOBJS)
-	$(CC) $(CFLAGS) $(MOBJS) -o $(BINDIR)\MakeArray
+	$(CC) $(CFLAGS) $(MOBJS) /Fo$(BINDIR)\MakeArray
 
 
-GOBJS    = GeneSeqer.obj \
-	   getgbs.obj \
-	   getlns.obj \
-	   getlps.obj \
-	   list.obj \
-	   result.obj \
-	   sahmtd.obj \
-	   sahmtp.obj \
-	   SufArray.obj \
-	   EstData.obj \
-	   LcpTree.obj \
-	   RawTextFile.obj \
-	   TopsPage.obj \
-	   TopsPost.obj \
-	   TopsSeq.obj \
-	   TopsWire.obj
+GOBJS = GeneSeqer.obj \
+	getgbs.obj \
+	getlns.obj \
+	getlps.obj \
+	list.obj \
+	result.obj \
+	sahmtd.obj \
+	sahmtp.obj \
+	SufArray.obj \
+	EstData.obj \
+	LcpTree.obj \
+	RawTextFile.obj \
+	TopsPage.obj \
+	TopsPost.obj \
+	TopsSeq.obj \
+	TopsWire.obj
 
 GeneSeqer:	$(GOBJS)
-	$(CC) $(CFLAGS) $(GOBJS) -o $(BINDIR)\GeneSeqer
+	$(CC) $(CFLAGS) $(GOBJS) /Fo$(BINDIR)\GeneSeqer
 
 
-SOBJS    = RawTextFile.obj \
-	   getgbs.obj \
-	   getlns.obj \
-	   getlps.obj \
-	   sahmtd.obj \
-	   sahmtp.obj
+SOBJS = RawTextFile.obj \
+	getgbs.obj \
+	getlns.obj \
+	getlps.obj \
+	sahmtd.obj \
+	sahmtp.obj
 
 SplicePredictor:	$(SOBJS)
-	$(CC) $(CFLAGS) -DDAPBM -DDAPBM7 SplicePredictor.c $(SOBJS) -o $(BINDIR)\SplicePredictor
+	$(CC) $(CFLAGS) -DDAPBM -DDAPBM7 SplicePredictor.c $(SOBJS) /Fo$(BINDIR)\SplicePredictor
 
 SplicePredictorLL:	$(SOBJS)
-	$(CC) $(CFLAGS) SplicePredictor.c $(SOBJS) -o $(BINDIR)\SplicePredictorLL
+	$(CC) $(CFLAGS) SplicePredictor.c $(SOBJS) /Fo$(BINDIR)\SplicePredictorLL
+
+%.obj: %.c
+	$(CC) -c $< /Fo$@ $(CFLAGS)


### PR DESCRIPTION
	- Check OS type for appropriate build
	- Modify compiler commands to be Windows compatible
	- Add a note for windows build in INSTALL.md
	- Change code that causes compiler errors on Windows